### PR TITLE
Updating Twitter handle and links

### DIFF
--- a/_template.html
+++ b/_template.html
@@ -79,7 +79,7 @@
         <div class="links">
           <a href="//azure.microsoft.com/">Azure.Microsoft.com</a> |
           <a href="http://blogs.msdn.com/b/windowsazure/">Azure Blog</a> |
-          <a href="https://twitter.com/windowsazure">@windowsazure</a> |
+          <a href="https://twitter.com/Azure">@Azure</a> |
           <a href="https://github.com/azure/">GitHub</a> |
           <a href="thanks.html">Thank you to our contributors</a>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -423,7 +423,7 @@
         <div class="links">
           <a href="//azure.microsoft.com/">Azure.Microsoft.com</a> |
           <a href="http://blogs.msdn.com/b/windowsazure/">Azure Blog</a> |
-          <a href="https://twitter.com/windowsazure">@windowsazure</a> |
+          <a href="https://twitter.com/Azure">@Azure</a> |
           <a href="https://github.com/azure/">GitHub</a> |
           <a href="thanks.html">Thank you to our contributors</a>
         </div>

--- a/guidelines.html
+++ b/guidelines.html
@@ -621,7 +621,7 @@ git config user.email YourAlias@YourEmailDomain</pre>
         <div class="links">
           <a href="//azure.microsoft.com/">Azure.Microsoft.com</a> |
           <a href="http://blogs.msdn.com/b/windowsazure/">Azure Blog</a> |
-          <a href="https://twitter.com/windowsazure">@windowsazure</a> |
+          <a href="https://twitter.com/Azure">@Azure</a> |
           <a href="https://github.com/azure/">GitHub</a> |
           <a href="thanks.html">Thank you to our contributors</a>
         </div>

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
         <div class="links">
           <a href="//azure.microsoft.com/">Azure.Microsoft.com</a> |
           <a href="http://blogs.msdn.com/b/windowsazure/">Azure Blog</a> |
-          <a href="https://twitter.com/windowsazure">@windowsazure</a> |
+          <a href="https://twitter.com/Azure">@Azure</a> |
           <a href="https://github.com/azure/">GitHub</a> |
           <a href="thanks.html">Thank you to our contributors</a>
         </div>

--- a/projects.html
+++ b/projects.html
@@ -322,7 +322,7 @@
         <div class="links">
           <a href="//azure.microsoft.com/">Azure.Microsoft.com</a> |
           <a href="http://blogs.msdn.com/b/windowsazure/">Azure Blog</a> |
-          <a href="https://twitter.com/windowsazure">@windowsazure</a> |
+          <a href="https://twitter.com/Azure">@Azure</a> |
           <a href="https://github.com/azure/">GitHub</a> |
           <a href="thanks.html">Thank you to our contributors</a>
         </div>

--- a/thanks.html
+++ b/thanks.html
@@ -211,7 +211,7 @@ src="https://1.gravatar.com/avatar/75752e740f4383e6f3eda0767789a815?d=https%3A%2
         <div class="links">
           <a href="//azure.microsoft.com/">Azure.Microsoft.com</a> |
           <a href="http://blogs.msdn.com/b/windowsazure/">Azure Blog</a> |
-          <a href="https://twitter.com/windowsazure">@windowsazure</a> |
+          <a href="https://twitter.com/Azure">@Azure</a> |
           <a href="https://github.com/azure/">GitHub</a> |
           <a href="thanks.html">Thank you to our contributors</a>
         </div>


### PR DESCRIPTION
Your Twitter moved from @microsoftazure to @Azure