### PR TITLE
Fix StackOverflow links

### DIFF
--- a/jekyll/guidelines.html
+++ b/jekyll/guidelines.html
@@ -124,11 +124,11 @@ permalink: /guidelines/
         </thead>
         <tbody>
         <tr>
-          <td style="min-width: 83px"><a href="//stackoverflow.com/tagged/azure"><img
+          <td style="min-width: 83px"><a href="//stackoverflow.com/questions/tagged/azure"><img
               src="{% asset_path stackoverflow.png %}" alt="StackOverflow" title="StackOverflow" style="width: 83px;height: 82px"/></a>
           </td>
-          <td><a href="//stackoverflow.com/tagged/azure"><h2>StackOverflow</h2></a></td>
-          <td><a href="//stackoverflow.com/tagged/azure">azure</a></td>
+          <td><a href="//stackoverflow.com/questions/tagged/azure"><h2>StackOverflow</h2></a></td>
+          <td><a href="//stackoverflow.com/questions/tagged/azure">azure</a></td>
           <td>A friendly, open and fun community of developers.</td>
         </tr>
         <tr>


### PR DESCRIPTION
Replace `tagged/azure` with `questions/tagged/azure` in URL